### PR TITLE
Removes retries if error code is 404

### DIFF
--- a/src/GoogleCloudStorage/GoogleCloudStorageProvider.php
+++ b/src/GoogleCloudStorage/GoogleCloudStorageProvider.php
@@ -43,7 +43,6 @@ class GoogleCloudStorageProvider extends ServiceProvider
     {
         $factory = $this->app->make('filesystem'); /* @var FilesystemManager $factory */
         $this->logger = new LogMonologAdapter();
-
         $factory->extend(
             'gcs',
             function ($app, $config) {
@@ -60,13 +59,15 @@ class GoogleCloudStorageProvider extends ServiceProvider
                                     'exception' => get_class($exception),
                                 ]
                             );
+                            if ($exception->getCode() == 404) {
+                                return false;
+                            }
                             return true;
                         },
                     ]
                 );
                 $bucket = $storageClient->bucket($config['bucket']);
                 $pathPrefix = array_get($config, 'path_prefix');;
-
                 $adapter = new GoogleStorageAdapter($storageClient, $bucket, $pathPrefix, $config);
                 return $this->createFilesystem($adapter, $config);
             }


### PR DESCRIPTION
To avoid unnecessary retries if the key was not found in the bucket,
a check in the error code has been added, if it is NOT_FOUND (404)
it doesn't retry.