### PR TITLE
Adds the function to retrieve all objects metadata by a prefix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019-2022 Arquivei
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/readme.md
+++ b/readme.md
@@ -6,13 +6,13 @@ This project is based-on League\Flysystem [http://flysystem.thephpleague.com/doc
 
 ## Version Compatibility
 
- Releases | Laravel
-:---------|:--------
- 4.x      | ^8.0
- 3.x      | ^7.15
- 2.x      | ^6.0
- 1.x      | ^5.7
- 
+| Releases | Laravel |
+|:---------|:--------|
+| 4.x      | ^8.0    |
+| 3.x      | ^7.15   |
+| 2.x      | ^6.0    |
+| 1.x      | ^5.7    |
+
 ## Installation
 
 ```bash
@@ -134,3 +134,7 @@ class IlluminateStorageAdapter
 }
 ```
 
+## Maintainers
+André Lázari <andre.lazari@arquivei.com.br>
+
+Thales Castro <thales.mendes@arquivei.com.br>

--- a/src/ArquiveiStorage/Adapters/GoogleCloudStorage.php
+++ b/src/ArquiveiStorage/Adapters/GoogleCloudStorage.php
@@ -47,7 +47,6 @@ class GoogleCloudStorage extends AbstractStorage implements StorageInterface
     {
         try {
             $bucket = $this->client->bucket($this->bucket);
-
             $storageObjects = $bucket->objects(['prefix' => $prefix]);
 
             $objectsMetadata = [];

--- a/src/ArquiveiStorage/Adapters/GoogleCloudStorage.php
+++ b/src/ArquiveiStorage/Adapters/GoogleCloudStorage.php
@@ -43,6 +43,27 @@ class GoogleCloudStorage extends AbstractStorage implements StorageInterface
         }
     }
 
+    public function getObjectsMetadataByPrefix(string $prefix): array
+    {
+        try {
+            $bucket = $this->client->bucket($this->bucket);
+
+            $storageObjects = $bucket->objects(['prefix' => $prefix]);
+
+            $objectsMetadata = [];
+            foreach ($storageObjects as $storageObject) {
+                $objectsMetadata[] = $storageObject->info();
+            }
+
+            return $objectsMetadata;
+        } catch (\Throwable $throwable) {
+            if ($throwable instanceof GoogleException) {
+                throw new ArquiveiStorageException($throwable, $throwable->getCode(), $throwable->getMessage());
+            }
+            throw $throwable;
+        }
+    }
+
     public function exists(string $key)
     {
         try {


### PR DESCRIPTION
On the `GoogleCloudStorage` adapter, creates the function `getObjectsMetadataByPrefix` to return an array of objects that match a given prefix